### PR TITLE
Fixed category id for acgnx.

### DIFF
--- a/OKP.Core/config/tags/acgnx_asia.json
+++ b/OKP.Core/config/tags/acgnx_asia.json
@@ -1,119 +1,119 @@
 {
   "Key": null,
-  "Value": "1-1",
+  "Value": "1",
   "SubTags": [
     {
       "Key": "Anime",
-      "Value": "1-1",
+      "Value": "1",
       "SubTags": [
         {
           "Key": "Collection",
-          "Value": "2-1",
+          "Value": "2",
           "SubTags": []
         }
       ]
     },
     {
       "Key": "Music",
-      "Value": "6-1",
+      "Value": "6",
       "SubTags": [
       {
           "Key": "ACG",
-          "Value": "7-1",
+          "Value": "7",
           "SubTags": []
         },
         {
           "Key": "Doujin",
-          "Value": "8-1",
+          "Value": "8",
           "SubTags": []
         },
         {
           "Key": "Pop",
-          "Value": "9-1",
+          "Value": "9",
           "SubTags": []
         }
       ]
     },{
       "Key": "Comic",
-      "Value": "3-1",
+      "Value": "3",
       "SubTags": [
         {
           "Key": "HongKong",
-          "Value": "4-1",
+          "Value": "4",
           "SubTags": []
         },
         {
           "Key": "Taiwan",
-          "Value": "4-1",
+          "Value": "4",
           "SubTags": []
         },
         {
           "Key": "Japanese",
-          "Value": "5-1",
+          "Value": "5",
           "SubTags": []
         }
       ]
     },{
       "Key": "Novel",
-      "Value": "3-1",
+      "Value": "3",
       "SubTags": [
         {
           "Key": "HongKong",
-          "Value": "4-1",
+          "Value": "4",
           "SubTags": []
         },
         {
           "Key": "Taiwan",
-          "Value": "4-1",
+          "Value": "4",
           "SubTags": []
         },
         {
           "Key": "Japanese",
-          "Value": "5-1",
+          "Value": "5",
           "SubTags": []
         }
       ]
     },{
       "Key": "Action",
-      "Value": "10-1",
+      "Value": "10",
       "SubTags": [
         {
           "Key": "Idol",
-          "Value": "19-1",
+          "Value": "19",
           "SubTags": []
         },
         {
           "Key": "Show",
-          "Value": "19-1",
+          "Value": "19",
           "SubTags": []
         },
         {
           "Key": "Tokusatsu",
-          "Value": "18-1",
+          "Value": "18",
           "SubTags": []
         },
         {
           "Key": "Raw",
-          "Value": "11-1",
+          "Value": "11",
           "SubTags": []
         }
       ]
     },{
       "Key": "Picture",
-      "Value": "19-1",
+      "Value": "19",
       "SubTags": []
     },{
       "Key": "Software",
-      "Value": "12-1",
+      "Value": "12",
       "SubTags": [
         {
           "Key": "ACG",
-          "Value": "17-1",
+          "Value": "17",
           "SubTags": []
         },
         {
           "Key": "App",
-          "Value": "19-1",
+          "Value": "19",
           "SubTags": []
         }
       ]

--- a/OKP.Core/config/tags/acgnx_global.json
+++ b/OKP.Core/config/tags/acgnx_global.json
@@ -1,124 +1,124 @@
 {
   "Key": null,
-  "Value": "4-1",
+  "Value": "4",
   "SubTags": [
     {
       "Key": "Anime",
-      "Value": "4-1",
+      "Value": "4",
       "SubTags": [
         {
           "Key": "MV",
-          "Value": "5-1",
+          "Value": "5",
           "SubTags": []
         },
         {
           "Key": "English",
-          "Value": "2-1",
+          "Value": "2",
           "SubTags": []
         },
         {
           "Key": "Raw",
-          "Value": "3-1",
+          "Value": "3",
           "SubTags": []
         }
       ]
     },
     {
       "Key": "Music",
-      "Value": "7-1",
+      "Value": "7",
       "SubTags": [
             {
             "Key": "Lossless",
-            "Value": "7-1",
+            "Value": "7",
             "SubTags": []
             },
             {
             "Key": "Lossy",
-            "Value": "8-1",
+            "Value": "8",
             "SubTags": []
             }
         ]
     },{
       "Key": "Comic",
-      "Value": "12-1",
+      "Value": "12",
       "SubTags": [
         {
           "Key": "English",
-          "Value": "10-1",
+          "Value": "10",
           "SubTags": []
         },
         {
           "Key": "Raw",
-          "Value": "11-1",
+          "Value": "11",
           "SubTags": []
         }
       ]
     },{
       "Key": "Novel",
-      "Value": "12-1",
+      "Value": "12",
       "SubTags": [
         {
           "Key": "English",
-          "Value": "10-1",
+          "Value": "10",
           "SubTags": []
         },
         {
           "Key": "Raw",
-          "Value": "11-1",
+          "Value": "11",
           "SubTags": []
         }
       ]
     },{
       "Key": "Action",
-      "Value": "16-1",
+      "Value": "16",
       "SubTags": [
         {
           "Key": "English",
-          "Value": "14-1",
+          "Value": "14",
           "SubTags": []
         },
         {
           "Key": "Idol",
-          "Value": "17-1",
+          "Value": "17",
           "SubTags": []
         },
         {
           "Key": "Show",
-          "Value": "16-1",
+          "Value": "16",
           "SubTags": []
         },
         {
           "Key": "Raw",
-          "Value": "15-1",
+          "Value": "15",
           "SubTags": []
         }
       ]
     },{
       "Key": "Picture",
-      "Value": "23-1",
+      "Value": "23",
       "SubTags": [
         {
           "Key": "Graphics",
-          "Value": "23-1",
+          "Value": "23",
           "SubTags": []
         },
         {
           "Key": "Photo",
-          "Value": "22-1",
+          "Value": "22",
           "SubTags": []
         }
       ]
     },{
       "Key": "Software",
-      "Value": "20-1",
+      "Value": "20",
       "SubTags": [
         {
           "Key": "App",
-          "Value": "19-1",
+          "Value": "19",
           "SubTags": []
         },{
           "Key": "Game",
-          "Value": "20-1",
+          "Value": "20",
           "SubTags": []
         }
       ]


### PR DESCRIPTION
Fixed category id for acgnx_asia and acgnx_global.
Since the "-1" in "4-1" is actually a page number, submitting it as such during the publishing process will result in a publishing failure.
So it needs to be fixed to the correct category id.