### PR TITLE
okp.core: bump version to 1.2.1

### DIFF
--- a/OKP.Core/OKP.Core.csproj
+++ b/OKP.Core/OKP.Core.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PublishAot>true</PublishAot>
-		<Version>1.1.2</Version>
+		<Version>1.2.1</Version>
 		<Copyright>Copyright (C) 2023-2026 AmusementClub
 Released under the GNU GPLv3+.
 		</Copyright>


### PR DESCRIPTION
## Summary

- bump the OKP.Core product version from 1.1.2 to 1.2.1
- make generated assembly/file/informational metadata and `--version` reflect the next release

The v1.2.0 tag currently still embeds product version 1.1.2, which makes release/version-based capability detection unreliable, making down stream OKPGUI-Next failed to gate acgrip api key behavior with version number

## Validation

- audited the repository for additional product-version sources; `OKP.Core/OKP.Core.csproj` is the only one
- confirmed dependency versions, `net10.0`, workflows, and documentation do not require changes
- `xmllint --noout OKP.Core/OKP.Core.csproj`
- `git diff --check`